### PR TITLE
Edit UI to encourage users to type commands and label.

### DIFF
--- a/src/components/CommandBar/autocomplete.js
+++ b/src/components/CommandBar/autocomplete.js
@@ -56,7 +56,7 @@ export default class Autocomplete extends React.Component {
     const inputProps = {
      //  autoFocus: true,
      value: this.state.value,
-     placeholder: "type here",
+     placeholder: "type command to modify plot",
      onChange: this.onChange,
      onKeyDown: e => this.props.inputProps.onKeyDown(e)
    };

--- a/src/components/LabelModal/index.js
+++ b/src/components/LabelModal/index.js
@@ -90,7 +90,7 @@ class LabelModal extends Component {
            &nbsp;&nbsp;
           <button className={classnames({active: this.props.issuedQuery.trim().length>0})} onClick={() => this.submit(this.props.issuedQuery)}>(label as correct)</button>
       </div>
-      <div className="info">if "{this.props.issuedQuery}" is wrong, can be said better, or rephrased, please type below and submit</div>
+      <div className="info">Please rephrase  "{this.props.issuedQuery}" in natural language if you think it can be said better or is incorrect, and press submit. Otherwise, label the original command as correct. </div>
       <input autoFocus ref={(input) => { this.textInput = input; }} className="label-box"
         type="text"
         value={this.state.inputValue}


### PR DESCRIPTION
Justification #1: Users are more inclined to type in command-like prompts if the text in query bar says "type command" rather than simply "type here". This also alleviates confusion of users, as last turk experiment showed was a significant issue. 

Justification #2: Right now, our model appears to be at a stage where the top candidates in the UI are not correct for many queries. Turkers will still likely select them. Thus, we want to encourage them to provide labels, and use the "Label as Correct" button as the last option. This will help us get more label data so we can improve the system to a point where users start to see more success with their queries. 